### PR TITLE
RequireJS on NodeJS (using amdefine) compatibility.

### DIFF
--- a/he.js
+++ b/he.js
@@ -304,17 +304,7 @@
 		'unescape': decode
 	};
 
-	// Some AMD build optimizers, like r.js, check for specific condition patterns
-	// like the following:
-	if (
-		typeof define == 'function' &&
-		typeof define.amd == 'object' &&
-		define.amd
-	) {
-		define(function() {
-			return he;
-		});
-	}	else if (freeExports && !freeExports.nodeType) {
+	if (freeExports && !freeExports.nodeType) {
 		if (freeModule) { // in Node.js or RingoJS v0.8.0+
 			freeModule.exports = he;
 		} else { // in Narwhal or RingoJS v0.7.0-
@@ -322,7 +312,17 @@
 				has(he, key) && (freeExports[key] = he[key]);
 			}
 		}
-	} else { // in Rhino or a web browser
+	// Some AMD build optimizers, like r.js, check for specific condition patterns
+	// like the following:
+	} else if (
+		typeof define == 'function' &&
+		typeof define.amd == 'object' &&
+		define.amd
+	) {
+		define(function() {
+			return he;
+		});
+	}	else { // in Rhino or a web browser
 		root.he = he;
 	}
 


### PR DESCRIPTION
"he" doesn't correctly exports it's API when used with RequireJS in "node-compatibility mode" as described here: http://requirejs.org/docs/node.html#nodeModules

I changed the order of environment detection logic to prevent amdefine's fake 'define' making wrong decision about AMD environment.
