### PR TITLE
add a licence declaration, to make this buildable as Webjar

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,7 @@
 {
 	"name": "he",
 	"version": "1.1.0",
+	"license": "MIT",
 	"main": "he.js",
 	"ignore": [
 		"bin",


### PR DESCRIPTION
http://www.webjars.org/bower insists on this.

I’ve deployed this (v1.1.0 plus this patch) as v1.1.0.1 on webjars.org to check that there are no other issues preventing that, and it worked (so I can now include it in our project). Please merge, for the next release.