### PR TITLE
documentation improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ he.encode('foo \0 bar');
 // → 'foo \0 bar'
 ```
 
+Adding the `strict` option (see below) will, however, cause invalid code points to throw an error, so the return value of this function will always be valid HTML or an error, independent on the input.
+
 The `options` object is optional. It recognizes the following properties:
 
 #### `useNamedReferences`


### PR DESCRIPTION
make it clear that the 'strict' option removes the input being valid constraint

(without 'strict', the output is only valid if the input is valid; some people require an encoder that takes **any** input, valid or not, and encodes it into valid output (or throws an exception if it cannot be encoded), i.e. does not silently pass invalid input into invalid output)