### PR TITLE
fix: gracefully handle falsy input

### DIFF
--- a/he.js
+++ b/he.js
@@ -138,6 +138,7 @@
 	/*--------------------------------------------------------------------------*/
 
 	var encode = function(string, options) {
+		if (!string) return string;
 		options = merge(options, encode.options);
 		var strict = options.strict;
 		if (strict && regexInvalidRawCodePoint.test(string)) {
@@ -224,6 +225,7 @@
 	};
 
 	var decode = function(html, options) {
+		if (!html) return html;
 		options = merge(options, decode.options);
 		var strict = options.strict;
 		if (strict && regexInvalidEntity.test(html)) {
@@ -301,7 +303,7 @@
 	};
 
 	var escape = function(string) {
-		return string.replace(regexEscape, function($0) {
+		return string && string.replace(regexEscape, function($0) {
 			// Note: there is no need to check `has(escapeMap, $0)` here.
 			return escapeMap[$0];
 		});

--- a/src/he.js
+++ b/src/he.js
@@ -146,6 +146,7 @@
 	/*--------------------------------------------------------------------------*/
 
 	var encode = function(string, options) {
+		if (!string) return string;
 		options = merge(options, encode.options);
 		var strict = options.strict;
 		if (strict && regexInvalidRawCodePoint.test(string)) {
@@ -232,6 +233,7 @@
 	};
 
 	var decode = function(html, options) {
+		if (!html) return html;
 		options = merge(options, decode.options);
 		var strict = options.strict;
 		if (strict && regexInvalidEntity.test(html)) {
@@ -309,7 +311,7 @@
 	};
 
 	var escape = function(string) {
-		return string.replace(regexEscape, function($0) {
+		return string && string.replace(regexEscape, function($0) {
 			// Note: there is no need to check `has(escapeMap, $0)` here.
 			return escapeMap[$0];
 		});

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -6364,13 +6364,32 @@
 			he.decode('&#00'),
 			'\uFFFD',
 			'Decoding `&#00` numeric character reference (see issue #43)'
-		),
+		);
 		equal(
 			he.decode('&#0128;'),
 			'\u20AC',
 			'Decoding `0`-prefixed numeric character referencs (see issue #43)'
-		)
-
+		);
+		equal(
+			he.decode(''),
+			'',
+			'Decode pass-thru empty string'
+		);
+		equal(
+			he.decode(null),
+			null,
+			'Decode pass-thru null'
+		);
+		equal(
+			he.decode(undefined),
+			undefined,
+			'Decode pass-thru undefined'
+		);
+		equal(
+			he.decode(false),
+			false,
+			'Decode pass-thru false'
+		);
 	});
 	test('encode', function() {
 		equal(
@@ -6709,6 +6728,26 @@
 			Error,
 			'Parse error: forbidden code point when `decimal: true`, `allowUnsafeSymbols: true` and `strict: true`'
 		);
+		equal(
+			he.encode(''),
+			'',
+			'Encode pass-thru empty string'
+		);
+		equal(
+			he.encode(null),
+			null,
+			'Encode pass-thru null'
+		);
+		equal(
+			he.encode(undefined),
+			undefined,
+			'Encode pass-thru undefined'
+		);
+		equal(
+			he.encode(false),
+			false,
+			'Encode pass-thru false'
+		);
 	});
 	test('escape', function() {
 		equal(
@@ -6725,6 +6764,46 @@
 			he.decode,
 			he.unescape,
 			'`decode` and `unescape` should be the same'
+		);
+		equal(
+			he.escape(''),
+			'',
+			'Escape pass-thru empty string'
+		);
+		equal(
+			he.escape(null),
+			null,
+			'Escape pass-thru null'
+		);
+		equal(
+			he.escape(undefined),
+			undefined,
+			'Escape pass-thru undefined'
+		);
+		equal(
+			he.unescape(false),
+			false,
+			'Unescape pass-thru false'
+		);
+		equal(
+			he.unescape(''),
+			'',
+			'Unescape pass-thru empty string'
+		);
+		equal(
+			he.unescape(null),
+			null,
+			'Unescape pass-thru null'
+		);
+		equal(
+			he.unescape(undefined),
+			undefined,
+			'Unescape pass-thru undefined'
+		);
+		equal(
+			he.unescape(false),
+			false,
+			'Unescape pass-thru false'
 		);
 	});
 

--- a/tests/tests.src.js
+++ b/tests/tests.src.js
@@ -6364,13 +6364,32 @@
 			he.decode('&#00'),
 			'\uFFFD',
 			'Decoding `&#00` numeric character reference (see issue #43)'
-		),
+		);
 		equal(
 			he.decode('&#0128;'),
 			'\u20AC',
 			'Decoding `0`-prefixed numeric character referencs (see issue #43)'
-		)
-
+		);
+		equal(
+			he.decode(''),
+			'',
+			'Decode pass-thru empty string'
+		);
+		equal(
+			he.decode(null),
+			null,
+			'Decode pass-thru null'
+		);
+		equal(
+			he.decode(undefined),
+			undefined,
+			'Decode pass-thru undefined'
+		);
+		equal(
+			he.decode(false),
+			false,
+			'Decode pass-thru false'
+		);
 	});
 	test('encode', function() {
 		equal(
@@ -6709,6 +6728,26 @@
 			Error,
 			'Parse error: forbidden code point when `decimal: true`, `allowUnsafeSymbols: true` and `strict: true`'
 		);
+		equal(
+			he.encode(''),
+			'',
+			'Encode pass-thru empty string'
+		);
+		equal(
+			he.encode(null),
+			null,
+			'Encode pass-thru null'
+		);
+		equal(
+			he.encode(undefined),
+			undefined,
+			'Encode pass-thru undefined'
+		);
+		equal(
+			he.encode(false),
+			false,
+			'Encode pass-thru false'
+		);
 	});
 	test('escape', function() {
 		equal(
@@ -6725,6 +6764,46 @@
 			he.decode,
 			he.unescape,
 			'`decode` and `unescape` should be the same'
+		);
+		equal(
+			he.escape(''),
+			'',
+			'Escape pass-thru empty string'
+		);
+		equal(
+			he.escape(null),
+			null,
+			'Escape pass-thru null'
+		);
+		equal(
+			he.escape(undefined),
+			undefined,
+			'Escape pass-thru undefined'
+		);
+		equal(
+			he.unescape(false),
+			false,
+			'Unescape pass-thru false'
+		);
+		equal(
+			he.unescape(''),
+			'',
+			'Unescape pass-thru empty string'
+		);
+		equal(
+			he.unescape(null),
+			null,
+			'Unescape pass-thru null'
+		);
+		equal(
+			he.unescape(undefined),
+			undefined,
+			'Unescape pass-thru undefined'
+		);
+		equal(
+			he.unescape(false),
+			false,
+			'Unescape pass-thru false'
 		);
 	});
 


### PR DESCRIPTION
Recently refactored from [`lodash.unescape`](https://lodash.com/docs/4.17.4#unescape) to `he.decode`, and things broke since this wasn't handling falsy values. This PR simply passes them through like lodash for all relevant methods.