### PR TITLE
package.json: only `directories.bin`

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A robust HTML entities encoder/decoder with full Unicode support.",
   "homepage": "https://mths.be/he",
   "main": "he.js",
-  "bin": "bin/he",
   "keywords": [
     "string",
     "entities",


### PR DESCRIPTION
Both `bin` and `directories.bin` are illegal, according to
https://docs.npmjs.com/files/package.json#directoriesbin

fixes #62 